### PR TITLE
Added Screenshot Utility for everythin except browser events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /dist/
 /node_modules/
 /case_study/
-logs/
 stuff_to_delete/
 PythonProgrammingOnWin32.pdf
 latex

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /dist/
 /node_modules/
 /case_study/
+logs/
+screenshots/
 stuff_to_delete/
 PythonProgrammingOnWin32.pdf
 latex

--- a/README.md
+++ b/README.md
@@ -336,3 +336,5 @@ After installing the dependencies, you can [run the tool](#4-run-main-logger).
   - The synthetic UI logs generated for the test are available at: https://tinyurl.com/yyk68psx.
   - The complete results can be analyzed at: https://tinyurl.com/y55v56qa.
 - **Agostinelli, S., Lupia, M., Marrella, A., Mecella, M.**: _[Automated Generation of Executable RPA Scripts from User Interface Logs](https://doi.org/10.1007/978-3-030-58779-6_8)_. In: 18th Int. Conf. on Business Process Management (RPA Forum). pp. 116-131 (2020)
+
+# Test

--- a/README.md
+++ b/README.md
@@ -336,5 +336,3 @@ After installing the dependencies, you can [run the tool](#4-run-main-logger).
   - The synthetic UI logs generated for the test are available at: https://tinyurl.com/yyk68psx.
   - The complete results can be analyzed at: https://tinyurl.com/y55v56qa.
 - **Agostinelli, S., Lupia, M., Marrella, A., Mecella, M.**: _[Automated Generation of Executable RPA Scripts from User Interface Logs](https://doi.org/10.1007/978-3-030-58779-6_8)_. In: 18th Int. Conf. on Business Process Management (RPA Forum). pp. 116-131 (2020)
-
-# Test

--- a/modules/GUI/GUI.py
+++ b/modules/GUI/GUI.py
@@ -311,6 +311,11 @@ class MainApplication(QMainWindow, QDialog):
         self.runButton.toggled.connect(self.officeGroupBox.setDisabled)
 
     def updateStartButtonState(self):
+        """
+        Controls the status of the "start logger" button.
+        If any CB is clicked it does update the status.
+        If any CB is active, the button stays active.
+        """
         if self.runButton.isEnabled() and not any([self.systemLoggerFilesFolder,
                     self.systemLoggerPrograms,
                     self.systemLoggerClipboard,

--- a/modules/GUI/GUI.py
+++ b/modules/GUI/GUI.py
@@ -146,36 +146,41 @@ class MainApplication(QMainWindow, QDialog):
 
         self.systemLoggerFilesFolderCB = QCheckBox("Files/Folders")
         self.systemLoggerFilesFolderCB.tag = "systemLoggerFilesFolder"
-        self.systemLoggerFilesFolderCB.stateChanged.connect(
-            self.handleCheckBox)
+        self.systemLoggerFilesFolderCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerFilesFolderCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerFilesFolderCB.setToolTip(
             "Log edits on files and folder like create, modify, delete and more")
 
         self.systemLoggerClipboardCB = QCheckBox("Clipboard")
         self.systemLoggerClipboardCB.tag = "systemLoggerClipboard"
         self.systemLoggerClipboardCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerClipboardCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerClipboardCB.setToolTip("Log clipboard copy")
 
         self.systemLoggerProgramsCB = QCheckBox("Programs")
         self.systemLoggerProgramsCB.tag = "systemLoggerPrograms"
         self.systemLoggerProgramsCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerProgramsCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerProgramsCB.setToolTip(
             "Log opening and closing of programs")
 
         self.systemLoggerHotkeysCB = QCheckBox("Hotkeys")
         self.systemLoggerHotkeysCB.tag = "systemLoggerHotkeys"
         self.systemLoggerHotkeysCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerHotkeysCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerHotkeysCB.setToolTip("Log system-wide hotkeys")
 
         self.systemLoggerUSBCB = QCheckBox("USB Drives")
         self.systemLoggerUSBCB.tag = "systemLoggerUSB"
         self.systemLoggerUSBCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerUSBCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerUSBCB.setToolTip(
             "Log insertion and removal of usb drives")
 
         self.systemLoggerEventsCB = QCheckBox("Events")
         self.systemLoggerEventsCB.tag = "systemLoggerEvents"
         self.systemLoggerEventsCB.stateChanged.connect(self.handleCheckBox)
+        self.systemLoggerEventsCB.stateChanged.connect(self.updateStartButtonState)
         self.systemLoggerEventsCB.setToolTip("Log edits on files and folder")
 
         layout = QVBoxLayout()
@@ -201,6 +206,7 @@ class MainApplication(QMainWindow, QDialog):
         self.officeExcelCB = QCheckBox("Excel")
         self.officeExcelCB.tag = "officeExcel"
         self.officeExcelCB.stateChanged.connect(self.handleCheckBox)
+        self.officeExcelCB.stateChanged.connect(self.updateStartButtonState)
         self.officeExcelNewRB = QRadioButton("New File")
         self.officeExcelNewRB.setChecked(True)
         self.officeExcelNewRB.setAutoExclusive(True)
@@ -214,6 +220,7 @@ class MainApplication(QMainWindow, QDialog):
         self.officeWordCB = QCheckBox("Word")
         self.officeWordCB.tag = "officeWord"
         self.officeWordCB.stateChanged.connect(self.handleCheckBox)
+        self.officeWordCB.stateChanged.connect(self.updateStartButtonState)
         self.officeWordNewRB = QRadioButton("New File")
         self.officeWordNewRB.setChecked(True)
         self.officeWordOpenRB = QRadioButton("Open File")
@@ -225,6 +232,7 @@ class MainApplication(QMainWindow, QDialog):
         self.officePowerpointCB = QCheckBox("PowerPoint")
         self.officePowerpointCB.tag = "officePowerpoint"
         self.officePowerpointCB.stateChanged.connect(self.handleCheckBox)
+        self.officePowerpointCB.stateChanged.connect(self.updateStartButtonState)
         self.officePowerpointNewRB = QRadioButton("New File")
         self.officePowerpointNewRB.setChecked(True)
         self.officePowerpointOpenRB = QRadioButton("Open File")
@@ -235,6 +243,7 @@ class MainApplication(QMainWindow, QDialog):
         self.officeOutlookCB = QCheckBox("Outlook")
         self.officeOutlookCB.tag = "officeOutlook"
         self.officeOutlookCB.stateChanged.connect(self.handleCheckBox)
+        self.officeOutlookCB.stateChanged.connect(self.updateStartButtonState)
 
         layout = QVBoxLayout()
         layout.addWidget(self.officeExcelCB)
@@ -259,18 +268,22 @@ class MainApplication(QMainWindow, QDialog):
         self.browserChromeCB = QCheckBox("Google Chrome")
         self.browserChromeCB.tag = "browserChrome"
         self.browserChromeCB.stateChanged.connect(self.handleCheckBox)
+        self.browserChromeCB.stateChanged.connect(self.updateStartButtonState)
 
         self.browserFirefoxCB = QCheckBox("Mozilla Firefox")
         self.browserFirefoxCB.tag = "browserFirefox"
         self.browserFirefoxCB.stateChanged.connect(self.handleCheckBox)
+        self.browserFirefoxCB.stateChanged.connect(self.updateStartButtonState)
 
         self.browserEdgeCB = QCheckBox("Microsoft Edge")
         self.browserEdgeCB.tag = "browserEdge"
         self.browserEdgeCB.stateChanged.connect(self.handleCheckBox)
+        self.browserEdgeCB.stateChanged.connect(self.updateStartButtonState)
 
         self.browserOperaCB = QCheckBox("Opera")
         self.browserOperaCB.tag = "browserOpera"
         self.browserOperaCB.stateChanged.connect(self.handleCheckBox)
+        self.browserOperaCB.stateChanged.connect(self.updateStartButtonState)
 
         layout = QVBoxLayout()
         layout.addWidget(self.browserChromeCB)
@@ -290,11 +303,32 @@ class MainApplication(QMainWindow, QDialog):
                 'QPushButton {background-color: #656565;}')
         self.runButton.setCheckable(True)
         self.runButton.setChecked(False)
+        self.runButton.setEnabled(False)
         self.runButton.clicked.connect(self.onButtonClick)
         self.runButton.toggled.connect(self.systemGroupBox.setDisabled)
         self.runButton.toggled.connect(self.browserGroupBox.setDisabled)
         self.runButton.toggled.connect(self.checkButton.setDisabled)
         self.runButton.toggled.connect(self.officeGroupBox.setDisabled)
+
+    def updateStartButtonState(self):
+        if self.runButton.isEnabled() and not any([self.systemLoggerFilesFolder,
+                    self.systemLoggerPrograms,
+                    self.systemLoggerClipboard,
+                    self.systemLoggerHotkeys,
+                    self.systemLoggerUSB,
+                    self.systemLoggerEvents,
+                    self.officeFilepath,
+                    self.officeExcel,
+                    self.officeWord,
+                    self.officePowerpoint,
+                    self.officeOutlook,
+                    self.browserChrome,
+                    self.browserFirefox,
+                    self.browserEdge,
+                    self.browserOpera]):
+            self.runButton.setEnabled(False)
+        else:
+            self.runButton.setEnabled(True)
 
     def createTopLayout(self):
         """

--- a/modules/GUI/PreferencesWindow.py
+++ b/modules/GUI/PreferencesWindow.py
@@ -70,7 +70,8 @@ class Preferences(QMainWindow):
         self.screenshot_cb.setToolTip("If enabled, screenshots will be stored for each recorded event in the log")
         self.screenshot_cb.tag = "screenshot_cb"
         self.screenshot_cb.stateChanged.connect(self.handle_cb_scrsht)
-        capture_screenshots = utils.config.MyConfig.get_instance().capture_screenshots
+        self.handle_cb_scrsht()
+        
         # self.decisionGroupBox.setEnabled(capture_screenshots)
 
         self.mfr = QRadioButton("Most frequent routine")
@@ -176,7 +177,7 @@ class Preferences(QMainWindow):
     def handle_cb_scrsht(self):
         perform = self.screenshot_cb.isChecked()
         # self.decisionGroupBox.setEnabled(perform)
-        utils.config.MyConfig.get_instance().capture_screenshot = perform
+        utils.config.MyConfig.get_instance().capture_screenshots = perform
         if perform:
             self.status_queue.put("[GUI] Screenshot capture enabled")
         else:

--- a/modules/GUI/PreferencesWindow.py
+++ b/modules/GUI/PreferencesWindow.py
@@ -24,6 +24,7 @@ class Preferences(QMainWindow):
         * enable or disable process discovery analysis
         * select the number of runs after which event log is generated
         * select analysis type (either decision points or most frequent routine)
+        * Future: enable or disable the screenshot recording feature
 
         :param status_queue: queue to send messages to main GUI
         """
@@ -62,6 +63,15 @@ class Preferences(QMainWindow):
         perform_process_discovery = utils.config.MyConfig.get_instance().perform_process_discovery
         self.process_discovery_cb.setChecked(perform_process_discovery)
         self.decisionGroupBox.setEnabled(perform_process_discovery)
+
+        # Additional Box to check the capture screenshots feature
+        self.screenshot_cb = QCheckBox(
+            "Enable screenshot feature on event logging")
+        self.screenshot_cb.setToolTip("If enabled, screenshots will be stored for each recorded event in the log")
+        self.screenshot_cb.tag = "screenshot_cb"
+        self.screenshot_cb.stateChanged.connect(self.handle_cb_scrsht)
+        capture_screenshots = utils.config.MyConfig.get_instance().capture_screenshots
+        # self.decisionGroupBox.setEnabled(capture_screenshots)
 
         self.mfr = QRadioButton("Most frequent routine")
         self.mfr.clicked.connect(self.handle_radio)
@@ -113,6 +123,11 @@ class Preferences(QMainWindow):
         vbox.addWidget(self.process_discovery_cb)
         processDiscoveryGroupBox.setLayout(vbox)
 
+        captureScreenshotsGroupBox = QGroupBox("capture Screenshots")
+        vbox = QVBoxLayout()
+        vbox.addWidget(self.screenshot_cb)
+        captureScreenshotsGroupBox.setLayout(vbox)
+
         vbox = QVBoxLayout()
         vbox.addWidget(self.mfr)
         vbox.addWidget(self.decision)
@@ -132,6 +147,7 @@ class Preferences(QMainWindow):
         xesGroupBox.setLayout(vbox)
 
         mainLayout = QVBoxLayout()
+        mainLayout.addWidget(captureScreenshotsGroupBox)
         mainLayout.addWidget(processDiscoveryGroupBox)
         mainLayout.addWidget(self.decisionGroupBox)
         mainLayout.addWidget(xesGroupBox)
@@ -156,6 +172,15 @@ class Preferences(QMainWindow):
             self.status_queue.put("[GUI] Process discovery enabled")
         else:
             self.status_queue.put("[GUI] Process discovery disabled")
+
+    def handle_cb_scrsht(self):
+        perform = self.screenshot_cb.isChecked()
+        # self.decisionGroupBox.setEnabled(perform)
+        utils.config.MyConfig.get_instance().capture_screenshot = perform
+        if perform:
+            self.status_queue.put("[GUI] Screenshot capture enabled")
+        else:
+            self.status_queue.put("[GUI] Screenshot capture disabled")
 
     def handle_radio(self):
         mfr_checked = self.mfr.isChecked()

--- a/modules/RPA/generateRPAScript.py
+++ b/modules/RPA/generateRPAScript.py
@@ -98,6 +98,15 @@ except ImportError as e:
 
         :return: browser import statement
         """
+        # In the following we can add edge driver as an element, to allow the execution of the RPA bot in Edge
+        # The following changes are necessary:
+        # broowser = webdriver.Chrome() < is replaced by:
+        # browser = webdriver.Edge(r"C:\Users\tomho\OneDrive\Documents\VSCode\smartRPA\smartRPA\libraries\msedgedriver.exe")
+        #
+        # The link to the file must be relative to the installation to find the Edge Driver.
+        # The file produced by the automated creation of the RPA bot needs to reference this msedgedriver.exe
+        #
+        # More on msedge Driver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
         return f"""
 try:
     import importlib

--- a/modules/consumerServer.py
+++ b/modules/consumerServer.py
@@ -90,6 +90,7 @@ def writeLog():
     with open(log_filepath, 'a', newline='', encoding='utf-8-sig') as out_file:
         f = csv.writer(out_file)
         f.writerow(row)
+        print("i have added a row")
 
     # empty the list for next use
     row.clear()

--- a/modules/consumerServer.py
+++ b/modules/consumerServer.py
@@ -90,7 +90,6 @@ def writeLog():
     with open(log_filepath, 'a', newline='', encoding='utf-8-sig') as out_file:
         f = csv.writer(out_file)
         f.writerow(row)
-        print("i have added a row")
 
     # empty the list for next use
     row.clear()

--- a/modules/consumerServer.py
+++ b/modules/consumerServer.py
@@ -39,7 +39,7 @@ HEADER = [
     "id", "title", "description", "browser_url", "eventQual", "tab_moved_from_index", "tab_moved_to_index",
     "newZoomFactor", "oldZoomFactor", "tab_pinned", "tab_audible", "tab_muted", "window_ingognito", "file_size",
     "tag_category", "tag_type", "tag_name", "tag_title", "tag_value", "tag_checked", "tag_html", "tag_href",
-    "tag_innerText", "tag_option", "tag_attributes", "xpath", "xpath_full"
+    "tag_innerText", "tag_option", "tag_attributes", "xpath", "xpath_full", "screenshot"
 ]
 
 

--- a/modules/events/clipboardEvents.py
+++ b/modules/events/clipboardEvents.py
@@ -25,13 +25,15 @@ def logClipboard():
         if temp_value != recent_value:
             recent_value = temp_value
             print(f"{timestamp()} {USER} Clipboard copy {recent_value}")
+            screenshot = takeScreenshot()
             session.post(consumerServer.SERVER_ADDR, json={
                 "timestamp": timestamp(),
                 "user": USER,
                 "category": "Clipboard",
                 "application": "Clipboard",
                 "event_type": "copy",
-                "clipboard_content": recent_value
+                "clipboard_content": recent_value,
+                "screenshot": screenshot
             })
         sleep(0.2)
 

--- a/modules/events/mouseEvents.py
+++ b/modules/events/mouseEvents.py
@@ -1,7 +1,7 @@
 from sys import path
 path.append('../../')  # this way main file is visible from this file
 from pynput import mouse
-import utils.utils
+from utils.utils import *
 from modules import consumerServer
 from deprecated.sphinx import deprecated
 
@@ -19,13 +19,15 @@ def logMouse():
             if 'Excel' in utils.utils.getActiveWindowInfo('name') and pressed:
                 coord = f"{x},{y}"
                 print(f"{utils.utils.timestamp()} {utils.utils.USER} OperatingSystem click {coord}")
+                screenshot = takeScreenshot()
                 utils.utils.session.post(consumerServer.SERVER_ADDR, json={
                     "timestamp": utils.utils.timestamp(),
                     "user": utils.utils.USER,
                     "category": "MouseClick",
                     "application": "OperatingSystem",
                     "event_type": "click",
-                    "mouse_coord": coord
+                    "mouse_coord": coord,
+                    "screenshot": screenshot
                 })
         except Exception:
             pass

--- a/modules/events/officeEvents.py
+++ b/modules/events/officeEvents.py
@@ -9,7 +9,7 @@ from re import findall
 import os
 from shutil import rmtree
 from itertools import chain
-import utils.utils
+from utils.utils import *
 from modules.consumerServer import SERVER_ADDR
 import utils.config
 
@@ -73,6 +73,7 @@ class ExcelEvents:
 
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} openWindow workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} window id:{Wn.WindowNumber} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -83,7 +84,8 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "id": Wn.WindowNumber,
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWindowDeactivate(self, Wb, Wn):
@@ -95,6 +97,7 @@ class ExcelEvents:
         :return: closeWindow event
         """
         self.seen_events["OnWindowDeactivate"] = None
+        screenshot = takeScreenshot()
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} closeWindow workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} window id:{Wn.WindowNumber} path: {Wb.Path}")
         utils.utils.session.post(SERVER_ADDR, json={
@@ -107,7 +110,8 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "id": Wn.WindowNumber,
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWindowResize(self, Wb, Wn):
@@ -119,6 +123,7 @@ class ExcelEvents:
         :return: resizeWindow event
         """
         x, y, width, height = utils.utils.getActiveWindowInfo('size')
+        screenshot = takeScreenshot()
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} resizeWindow workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} window id:{Wn.WindowNumber} size {x},{y},{width},{height} ")
         utils.utils.session.post(SERVER_ADDR, json={
@@ -132,7 +137,8 @@ class ExcelEvents:
             "worksheets": self.getWorksheets(None, Wb),
             "id": Wn.WindowNumber,
             "event_src_path": Wb.Path,
-            "window_size": f"{x},{y},{width},{height}"
+            "window_size": f"{x},{y},{width},{height}",
+            "screenshot": screenshot
             # "window_size": f"{Wn.Width},{Wn.Height}"
         })
 
@@ -152,6 +158,7 @@ class ExcelEvents:
         x, y, width, height = utils.utils.getActiveWindowInfo('size')
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} newWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path} window_size {x},{y},{width},{height}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -162,7 +169,8 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-            "window_size": f"{x},{y},{width},{height}"
+            "window_size": f"{x},{y},{width},{height}",
+            "screenshot": screenshot
         })
 
     def OnWorkbookOpen(self, Wb):
@@ -175,6 +183,7 @@ class ExcelEvents:
         path = os.path.join(Wb.Path, Wb.Name)
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} openWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -184,7 +193,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": path
+            "event_src_path": path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookNewSheet(self, Wb, Sh):
@@ -197,6 +207,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} addWorksheet workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -207,7 +218,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookBeforeSave(self, Wb, SaveAsUI, Cancel):
@@ -225,6 +236,7 @@ class ExcelEvents:
             description = "SaveAs dialog box displayed"
         else:
             description = "SaveAs dialog box not displayed"
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -235,7 +247,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "description": description,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookAfterSave(self, Wb, Success):
@@ -249,6 +261,7 @@ class ExcelEvents:
         savedPath = os.path.join(Wb.Path, Wb.Name)
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} saveWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {savedPath}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -259,7 +272,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": savedPath,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookAddinInstall(self, Wb):
@@ -271,6 +284,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} addinInstalledWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -280,7 +294,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookAddinUninstall(self, Wb):
@@ -292,6 +307,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} addinUninstalledWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -301,7 +317,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookAfterXmlImport(self, Wb, Map, Url, Result):
@@ -316,6 +333,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} XMLImportWOrkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -325,7 +343,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookAfterXmlExport(self, Wb, Map, Url, Result):
@@ -340,6 +359,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} XMLExportWOrkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -349,7 +369,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookBeforePrint(self, Wb, Cancel):
@@ -362,6 +383,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} printWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -372,7 +394,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookBeforeClose(self, Wb, Cancel):
@@ -385,6 +407,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} closeWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -395,7 +418,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookActivate(self, Wb):
@@ -407,6 +430,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} activateWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -417,7 +441,7 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookDeactivate(self, Wb):
@@ -429,6 +453,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} deactivateWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -439,12 +464,13 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-
+            "screenshot": screenshot
         })
 
     def OnWorkbookModelChange(self, Wb, Changes):
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} modelChangeWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -454,7 +480,8 @@ class ExcelEvents:
             "workbook": Wb.Name,
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
-            "event_src_path": Wb.Path
+            "event_src_path": Wb.Path,
+            "screenshot": screenshot
         })
 
     def OnWorkbookNewChart(self, Wb, Ch):
@@ -467,6 +494,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} newChartWorkbook workbook: {Wb.Name} Worksheet:{Wb.ActiveSheet.Name} path: {Wb.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -477,7 +505,8 @@ class ExcelEvents:
             "current_worksheet": Wb.ActiveSheet.Name,
             "worksheets": self.getWorksheets(None, Wb),
             "event_src_path": Wb.Path,
-            "title": Ch.Name
+            "title": Ch.Name,
+            "screenshot": screenshot
         })
 
     def OnAfterCalculate(self):
@@ -488,12 +517,14 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} afterCalculate")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Excel",
             "event_type": "afterCalculate",
+            "screenshot": screenshot
         })
 
     # ************
@@ -532,6 +563,7 @@ class ExcelEvents:
         # to get the list of active worksheet names, I cycle through the parent which is the workbook
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel selectWorksheet {Sh.Name} {Sh.Parent.Name} {self.getWorksheets(Sh, None)}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -542,6 +574,7 @@ class ExcelEvents:
             "current_worksheet": Sh.Name,
             "worksheets": self.getWorksheets(Sh, None),
             "event_src_path": Sh.Parent.Path,
+            "screenshot": screenshot
 
         })
 
@@ -554,6 +587,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel deleteWorksheet {Sh.Name} {Sh.Parent.Name} {self.getWorksheets(Sh, None)}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -563,6 +597,7 @@ class ExcelEvents:
             "workbook": Sh.Parent.Name,
             "current_worksheet": Sh.Name,
             "worksheets": self.getWorksheets(Sh, None),
+            "screenshot": screenshot
 
         }),
 
@@ -583,6 +618,7 @@ class ExcelEvents:
 
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel {event_type} {Sh.Name} {Sh.Parent.Name} {Target.Address.replace('$', '')} {value}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -593,6 +629,7 @@ class ExcelEvents:
             "current_worksheet": Sh.Name,
             "cell_range": Target.Address.replace('$', ''),
             "cell_content": value,
+            "screenshot": screenshot
 
         })
 
@@ -612,6 +649,7 @@ class ExcelEvents:
             value = Target.Value
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel {event_type} {Sh.Name} {Sh.Parent.Name} {Target.Address.replace('$', '')} {value}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -622,6 +660,7 @@ class ExcelEvents:
             "current_worksheet": Sh.Name,
             "cell_range": Target.Address.replace('$', ''),
             "cell_content": value,
+            "screenshot": screenshot
 
         })
 
@@ -634,6 +673,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel sheetCalculate {Sh.Name} {Sh.Parent.Name} ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -642,6 +682,7 @@ class ExcelEvents:
             "event_type": "sheetCalculate",
             "workbook": Sh.Parent.Name,
             "current_worksheet": Sh.Name,
+            "screenshot": screenshot
 
         })
 
@@ -683,6 +724,7 @@ class ExcelEvents:
 
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel editCellSheet {Sh.Name} {Sh.Parent.Name} {cell_range} ({cell_range_number}) {value}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -694,6 +736,7 @@ class ExcelEvents:
             "cell_range": cell_range,
             "cell_range_number": cell_range_number,
             "cell_content": value,
+            "screenshot": screenshot
 
         })
 
@@ -707,6 +750,7 @@ class ExcelEvents:
         self.seen_events["OnSheetDeactivate"] = None
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel deselectWorksheet {Sh.Name} {Sh.Parent.Name} {self.getWorksheets(Sh, None)}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -717,6 +761,7 @@ class ExcelEvents:
             "current_worksheet": Sh.Name,
             "worksheets": self.getWorksheets(Sh, None),
             "event_src_path": Sh.Parent.Path,
+            "screenshot": screenshot
 
         })
 
@@ -730,6 +775,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel followHiperlinkSheet {Sh.Name} {Sh.Parent.Name} {Target.Range.Address.replace('$', '')} {Target.Address}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -740,6 +786,7 @@ class ExcelEvents:
             "current_worksheet": Sh.Name,
             "cell_range": Target.Range.Address.replace('$', ''),
             "browser_url": Target.Address,
+            "screenshot": screenshot
 
         })
 
@@ -754,6 +801,7 @@ class ExcelEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel pivotTableValueChangeSheet {Sh.Name} {Sh.Parent.Name} {TargetRange.Address.replace('$', '')} {TargetRange.Value}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -763,7 +811,8 @@ class ExcelEvents:
             "workbook": Sh.Parent.Name,
             "current_worksheet": Sh.Name,
             "cell_range": TargetRange.Address.replace('$', ''),
-            "cell_content": TargetRange.Value if TargetRange.Value else ""
+            "cell_content": TargetRange.Value if TargetRange.Value else "",
+            "screenshot": screenshot
         })
 
     def OnSheetSelectionChange(self, Sh, Target):
@@ -790,6 +839,7 @@ class ExcelEvents:
         if rangeSelected or self.LOG_EVERY_CELL:
             print(
                 f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel {event_type} {Sh.Name} {Sh.Parent.Name} {cells_selected} ({cell_range_number}) {value}")
+            screenshot = takeScreenshot()
             utils.utils.session.post(SERVER_ADDR, json={
                 "timestamp": utils.utils.timestamp(),
                 "user": utils.utils.USER,
@@ -801,6 +851,7 @@ class ExcelEvents:
                 "cell_range": cells_selected,
                 "cell_range_number": cell_range_number,
                 "cell_content": value,
+                "screenshot": screenshot
 
             })
 
@@ -813,6 +864,7 @@ class ExcelEvents:
         :return: worksheetTableUpdated event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Microsoft Excel worksheetTableUpdated {Sh.Name} {Sh.Parent.Name} ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -821,6 +873,7 @@ class ExcelEvents:
             "event_type": "worksheetTableUpdated",
             "workbook": Sh.Parent.Name,
             "current_worksheet": Sh.Name,
+            "screenshot": screenshot
         })
 
 
@@ -889,13 +942,15 @@ def excelEventsMacServer(status_queue, excelFilepath=None):
     macExcelAddinPath = os.path.join(utils.utils.MAIN_DIRECTORY, 'extensions', 'excelAddinMac')
     # os.system(f"cd {macExcelAddinPath} && npm run dev-server >/dev/null 2>&1") # hide output
     if not utils.utils.utils.utils.isPortInUse(3000):
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Excel (MacOS)",
             "event_type": "openWorkbook",
-            "event_src_path": excelFilepath if excelFilepath else ""
+            "event_src_path": excelFilepath if excelFilepath else "",
+            "screenshot": screenshot
         })
         if excelFilepath:
             app = xw.App(visible=True)
@@ -936,12 +991,14 @@ class WordEvents:
         self.seen_events["OnWindowActivate"] = None
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} activateWindow")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "activateWindow",
+            "screenshot": screenshot
         })
 
     def OnWindowDeactivate(self, Doc, Wn):
@@ -956,12 +1013,14 @@ class WordEvents:
         self.seen_events["OnWindowActivate"] = None
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} deactivateWindow")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "deactivateWindow",
+            "screenshot": screenshot
         })
 
     def OnWindowBeforeDoubleClick(self, Sel, Cancel):
@@ -976,12 +1035,14 @@ class WordEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} doubleClickWindow")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "doubleClickWindow",
+            "screenshot": screenshot
         })
 
     def OnWindowBeforeRightClick(self, Sel, Cancel):
@@ -994,12 +1055,14 @@ class WordEvents:
         """
 
         print(f"{utils.utils.timestamp()} {utils.utils.USER} rightClickWindow")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "rightClickWindow",
+            "screenshot": screenshot
         })
 
     # Too much spam
@@ -1026,12 +1089,14 @@ class WordEvents:
         """
         self.seen_events["OnNewDocument"] = None
         print(f"{utils.utils.timestamp()} {utils.utils.USER} newDocument")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "newDocument",
+            "screenshot": screenshot
         })
 
     def OnDocumentOpen(self, Doc):
@@ -1042,12 +1107,14 @@ class WordEvents:
         :return: openDocument event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} openDocument")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "openDocument",
+            "screenshot": screenshot
         })
 
     def OnDocumentChange(self):
@@ -1058,12 +1125,14 @@ class WordEvents:
         """
         self.seen_events["OnDocumentChange"] = None
         print(f"{utils.utils.timestamp()} {utils.utils.USER} changeDocument")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "changeDocument",
+            "screenshot": screenshot
         })
 
     def OnDocumentBeforeSave(self, Doc, SaveAsUI, Cancel):
@@ -1076,12 +1145,14 @@ class WordEvents:
         :return: saveDocument event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} saveDocument")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "saveDocument",
+            "screenshot": screenshot
         })
 
     def OnDocumentBeforePrint(self, Doc, Cancel):
@@ -1093,12 +1164,14 @@ class WordEvents:
        :return: saveDocument event
        """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} printDocument")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Word",
             "event_type": "printDocument",
+            "screenshot": screenshot
         })
 
     def OnQuit(self):
@@ -1179,6 +1252,7 @@ class PowerpointEvents:
         :return: activateWindow event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint activateWindow {Pres.Name} {Pres.Path} ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1187,6 +1261,7 @@ class PowerpointEvents:
             "event_type": "activateWindow",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
+            "screenshot": screenshot
 
         })
 
@@ -1199,6 +1274,7 @@ class PowerpointEvents:
         :return: deactivateWindow event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint deactivateWindow {Pres.Name} {Pres.Path} ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1207,6 +1283,7 @@ class PowerpointEvents:
             "event_type": "deactivateWindow",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
+            "screenshot": screenshot
 
         })
 
@@ -1221,12 +1298,14 @@ class PowerpointEvents:
         print(Sel.SlideRange)
         print(Sel.TextRange)
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint rightClickPresentation ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Powerpoint",
             "event_type": "rightClickPresentation",
+            "screenshot": screenshot
 
         })
 
@@ -1241,12 +1320,14 @@ class PowerpointEvents:
         print(Sel.SlideRange)
         print(Sel.TextRange)
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint doubleClickPresentation ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Powerpoint",
             "event_type": "doubleClickPresentation",
+            "screenshot": screenshot
 
         })
 
@@ -1263,6 +1344,7 @@ class PowerpointEvents:
         """
         self.presentationSlides.clear()
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint newPresentation {Pres.Name} {Pres.Path}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1271,6 +1353,7 @@ class PowerpointEvents:
             "event_type": "newPresentation",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
+            "screenshot": screenshot
 
         })
 
@@ -1284,6 +1367,7 @@ class PowerpointEvents:
         self.addSlide(Sld)
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint newPresentationSlide {Sld.Name} {Sld.SlideNumber} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1293,6 +1377,7 @@ class PowerpointEvents:
             "title": Sld.Name,
             "id": Sld.SlideNumber,
             "slides": self.getSlides(),
+            "screenshot": screenshot
 
         })
 
@@ -1306,6 +1391,7 @@ class PowerpointEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint closePresentation {Pres.Name} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1315,6 +1401,7 @@ class PowerpointEvents:
             "title": Pres.Name,
             "event_src_path": Pres.Path,
             "slides": self.getSlides(),
+            "screenshot": screenshot
 
         })
         self.presentationSlides.clear()
@@ -1329,6 +1416,7 @@ class PowerpointEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint savePresentation {Pres.Name} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1338,7 +1426,7 @@ class PowerpointEvents:
             "title": Pres.Name,
             "event_src_path": Pres.Path,
             "slides": self.getSlides(),
-
+            "screenshot": screenshot
         })
 
     def OnAfterPresentationOpen(self, Pres):
@@ -1351,6 +1439,7 @@ class PowerpointEvents:
         self.presentationSlides.clear()
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint openPresentation {Pres.Name} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1359,7 +1448,8 @@ class PowerpointEvents:
             "event_type": "openPresentation",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
-            "slides": self.getSlides()
+            "slides": self.getSlides(),
+            "screenshot": screenshot
         })
 
     def OnAfterShapeSizeChange(self, shp):
@@ -1371,13 +1461,15 @@ class PowerpointEvents:
         """
         self.presentationSlides.clear()
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint shapeSizeChangePresentation {shp.Type} ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Powerpoint",
             "event_type": "shapeSizeChangePresentation",
-            "description": shp.Type
+            "description": shp.Type,
+            "screenshot": screenshot
         })
 
     def OnPresentationPrint(self, Pres):
@@ -1389,6 +1481,7 @@ class PowerpointEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint printPresentation {Pres.Name} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1397,7 +1490,8 @@ class PowerpointEvents:
             "event_type": "printPresentation",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
-            "slides": self.getSlides()
+            "slides": self.getSlides(),
+            "screenshot": screenshot
         })
 
     def OnSlideShowBegin(self, Wn):
@@ -1408,6 +1502,7 @@ class PowerpointEvents:
         :return: slideshowBegin event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint slideshowBegin ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1418,7 +1513,8 @@ class PowerpointEvents:
             "description": Wn.State,
             # https://docs.microsoft.com/en-us/office/vba/api/powerpoint.slideshowview.state
             "newZoomFactor": Wn.Zoom,
-            "slides": Wn.Slide.Name
+            "slides": Wn.Slide.Name,
+            "screenshot": screenshot
         })
 
     def OnSlideShowOnNext(self, Wn):
@@ -1429,6 +1525,7 @@ class PowerpointEvents:
         :return: nextSlideshow
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint nextSlideshow ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1439,7 +1536,8 @@ class PowerpointEvents:
             "description": Wn.State,
             # https://docs.microsoft.com/en-us/office/vba/api/powerpoint.slideshowview.state
             "newZoomFactor": Wn.Zoom,
-            "slides": Wn.Slide.Name
+            "slides": Wn.Slide.Name,
+            "screenshot": screenshot
         })
 
     def OnSlideShowNextClick(self, Wn, nEffect):
@@ -1453,6 +1551,7 @@ class PowerpointEvents:
         :return: clickNextSlideshow event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint clickNextSlideshow ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1464,7 +1563,8 @@ class PowerpointEvents:
             # https://docs.microsoft.com/en-us/office/vba/api/powerpoint.slideshowview.state
             "newZoomFactor": Wn.Zoom,
             "slides": Wn.Slide.Name,
-            "effect": nEffect.EffectType
+            "effect": nEffect.EffectType,
+            "screenshot": screenshot
         })
 
     def OnSlideShowOnPrevious(self, Wn):
@@ -1477,6 +1577,7 @@ class PowerpointEvents:
         :return: previousSlideshow event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint previousSlideshow ")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1486,7 +1587,8 @@ class PowerpointEvents:
             "title": Wn.SlideShowName,
             "description": Wn.State,
             "newZoomFactor": Wn.Zoom,
-            "slides": Wn.Slide.Name
+            "slides": Wn.Slide.Name,
+            "screenshot": screenshot
         })
 
     def OnSlideShowEnd(self, Pres):
@@ -1498,6 +1600,7 @@ class PowerpointEvents:
         """
         print(
             f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint slideshowEnd {Pres.Name} {self.getSlides()}")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
@@ -1506,7 +1609,8 @@ class PowerpointEvents:
             "event_type": "slideshowEnd",
             "title": Pres.Name,
             "event_src_path": Pres.Path,
-            "slides": self.getSlides()
+            "slides": self.getSlides(),
+            "screenshot": screenshot
         })
 
     def OnSlideSelectionChanged(self, SldRange):
@@ -1517,12 +1621,14 @@ class PowerpointEvents:
         :return: SlideSelectionChanged event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Powerpoint SlideSelectionChanged")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Powerpoint",
             "event_type": "SlideSelectionChanged",
+            "screenshot": screenshot
         })
 
 
@@ -1580,12 +1686,14 @@ class OutlookEvents:
         :return: startupOutlook event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook startupOutlook")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "startupOutlook",
+            "screenshot": screenshot
         })
 
     def OnQuit(self):
@@ -1596,12 +1704,14 @@ class OutlookEvents:
         """
         self.seen_events["OnQuit"] = None
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook quitOutlook")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "quitOutlook",
+            "screenshot": screenshot
         })
         # stopEvent.set() #Set the internal flag to true. All threads waiting for it to become true are awakened
         # To stop PumpMessages() when Outlook Quit
@@ -1616,12 +1726,14 @@ class OutlookEvents:
         :return: receiveMail event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook receiveMail")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "receiveMail",
+            "screenshot": screenshot
         })
         # RecrivedItemIDs is a collection of mail IDs separated by a ",".
         # You know, sometimes more than 1 mail is received at the same moment.
@@ -1640,12 +1752,14 @@ class OutlookEvents:
         """
         print(Item)
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook sendMail")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "sendMail",
+            "screenshot": screenshot
         })
 
     def OnMAPILogonComplete(self):
@@ -1655,12 +1769,14 @@ class OutlookEvents:
         :return: logonComplete event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook logonComplete")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "logonComplete",
+            "screenshot": screenshot
         })
 
     def OnReminder(self, Item):
@@ -1671,12 +1787,14 @@ class OutlookEvents:
         :return: newReminder event
         """
         print(f"{utils.utils.timestamp()} {utils.utils.USER} Outlook newReminder")
+        screenshot = takeScreenshot()
         utils.utils.session.post(SERVER_ADDR, json={
             "timestamp": utils.utils.timestamp(),
             "user": utils.utils.USER,
             "category": "MicrosoftOffice",
             "application": "Microsoft Outlook",
             "event_type": "newReminder",
+            "screenshot": screenshot
         })
 
 

--- a/modules/events/systemEvents.py
+++ b/modules/events/systemEvents.py
@@ -66,6 +66,7 @@ def watchFolder():
                 if event.event_type == "moved":  # destination path is available
                     print(
                         f"{timestamp()} {USER} OperatingSystem {event.event_type} {event.src_path} {event.dest_path}")
+                    screenshot = takeScreenshot()
                     session.post(consumerServer.SERVER_ADDR, json={
                         "timestamp": timestamp(),
                         "user": USER,
@@ -74,7 +75,8 @@ def watchFolder():
                         "event_type": event.event_type,
                         "event_src_path": event.src_path,
                         "event_dest_path": event.dest_path,
-                        "mouse_coord": mouse.position
+                        "mouse_coord": mouse.position,
+                        "screenshot": screenshot
                     })
                     # return
                 elif event.event_type == "modified":  # avoid spam
@@ -84,6 +86,7 @@ def watchFolder():
                     if "~$" not in event.src_path:
                         print(
                             f"{timestamp()} {USER} OperatingSystem {event.event_type} {event.src_path}")
+                        screenshot = takeScreenshot()
                         session.post(consumerServer.SERVER_ADDR, json={
                             "timestamp": timestamp(),
                             "user": USER,
@@ -91,7 +94,8 @@ def watchFolder():
                             "application": "Finder" if MAC else "Explorer",
                             "event_type": event.event_type,
                             "event_src_path": event.src_path,
-                            "mouse_coord": mouse.position
+                            "mouse_coord": mouse.position,
+                            "screenshot": screenshot
                         })
 
     print("[systemEvents] Files/Folder logging started")
@@ -199,6 +203,7 @@ def watchFolderMac():
             logged[path] = event_type
             # file_extension = os.path.splitext(path)[1]
             print(f"{timestamp()} {USER} OperatingSystem {event_type} {file_event.name}")
+            screenshot = takeScreenshot()
             session.post(consumerServer.SERVER_ADDR, json={
                 "timestamp": timestamp(),
                 "user": USER,
@@ -206,7 +211,8 @@ def watchFolderMac():
                 "application": "Finder" if MAC else "Explorer",
                 "event_type": event_type,
                 "event_src_path": file_event.name,
-                "mouse_coord": mouse.position
+                "mouse_coord": mouse.position,
+                "screenshot": screenshot
             })
 
     print("[systemEvents] Files/Folder logging started")
@@ -238,6 +244,7 @@ def logProcessesWin():
             exe = []
         path = exe[0] if exe else ""
         print(f"{timestamp()} {USER} {event} {app} {path}")
+        screenshot = takeScreenshot()
         session.post(consumerServer.SERVER_ADDR, json={
             "timestamp": timestamp(),
             "user": USER,
@@ -245,7 +252,8 @@ def logProcessesWin():
             "application": app,
             "event_type": event,
             "event_src_path": path,
-            "mouse_coord": mouse.position
+            "mouse_coord": mouse.position,
+            "screenshot": screenshot
         })
 
     new_programs = set()  # needed later to initialize 'closed' set
@@ -371,6 +379,7 @@ def watchRecentsFilesWin():
                     eventType = "openFolder"
 
                 print(f"{timestamp()} {USER} OperatingSystem {eventType} {lnk_target}")
+                screenshot = takeScreenshot()
                 session.post(consumerServer.SERVER_ADDR, json={
                     "timestamp": timestamp(),
                     "user": USER,
@@ -378,7 +387,8 @@ def watchRecentsFilesWin():
                     "application": "Finder" if MAC else "Explorer",
                     "event_type": eventType,
                     "event_src_path": lnk_target,
-                    "mouse_coord": mouse.position
+                    "mouse_coord": mouse.position,
+                    "screenshot": screenshot
                 })
 
         except Exception:
@@ -426,6 +436,7 @@ def detectSelectionWindowsExplorer():
                             else:
                                 eventType = "selectedFolder"
                             print(f"{timestamp()} {USER} OperatingSystem {eventType} {path}")
+                            screenshot = takeScreenshot()
                             session.post(consumerServer.SERVER_ADDR, json={
                                 "timestamp": timestamp(),
                                 "user": USER,
@@ -433,7 +444,8 @@ def detectSelectionWindowsExplorer():
                                 "application": "Explorer",
                                 "event_type": eventType,
                                 "event_src_path": path,
-                                "mouse_coord": mouse.position
+                                "mouse_coord": mouse.position,
+                                "screenshot": screenshot
                             })
         except Exception as e:
             # print(e)
@@ -506,6 +518,7 @@ def logHotkeys():
         if hotkey == "ctrl+h" and 'chrome' in appName.lower():
             meaning = "Show history"
         print(f"{timestamp()} {USER} OperatingSystem {event_type} {hotkey.upper()} {meaning} {clipboard_content}")
+        screenshot = takeScreenshot()
         session.post(consumerServer.SERVER_ADDR, json={
             "timestamp": timestamp(),
             "user": USER,
@@ -516,7 +529,8 @@ def logHotkeys():
             "hotkey": hotkey.upper(),
             "description": meaning,
             "clipboard_content": clipboard_content,
-            "mouse_coord": mouse.position
+            "mouse_coord": mouse.position,
+            "screenshot": screenshot
         })
 
     def handleHotkey(key):
@@ -550,6 +564,7 @@ def logPasteHotkey():
             # remove milliseconds from timestamp so duplicated events are easier to remove
             ts = timestamp()[:-3] + '000'
             print(f"{ts} {USER} OperatingSystem paste CTRL+V Paste {clipboard_content}")
+            screenshot = takeScreenshot()
             session.post(consumerServer.SERVER_ADDR, json={
                 "timestamp": ts,
                 "user": USER,
@@ -558,7 +573,8 @@ def logPasteHotkey():
                 "title": window_name,
                 "event_type": 'paste',
                 "description": 'Paste',
-                "clipboard_content": clipboard_content
+                "clipboard_content": clipboard_content,
+                "screenshot": screenshot
             })
 
     def handleHotkey():
@@ -613,6 +629,7 @@ def logUSBDrives():
             if id not in drive_list.keys():
                 drive_list[id] = DiskDrive_Caption
                 print(f"{timestamp()} {USER} OperatingSystem insertUSB {id} {DiskDrive_Caption}")
+                screenshot = takeScreenshot()
                 session.post(consumerServer.SERVER_ADDR, json={
                     "timestamp": timestamp(),
                     "user": USER,
@@ -621,6 +638,7 @@ def logUSBDrives():
                     "event_type": "insertUSB",
                     "id": id,
                     "title": DiskDrive_Caption,
+                    "screenshot": screenshot
                 })
         else:
             drive_list.clear()
@@ -653,6 +671,7 @@ def logProcessesMac():
                 if app not in open_programs:
                     open_programs.append(app)
                     print(f"{timestamp()} {USER} programOpen {app.strip()}.app")
+                    screenshot = takeScreenshot()
                     session.post(consumerServer.SERVER_ADDR, json={
                         "timestamp": timestamp(),
                         "user": USER,
@@ -660,7 +679,8 @@ def logProcessesMac():
                         "application": app.strip(),
                         "event_type": "programOpen",
                         "event_src_path": f"/Applications/{app.strip()}.app",
-                        "mouse_coord": mouse.position
+                        "mouse_coord": mouse.position,
+                        "screenshot": screenshot
                     })
             new_programs_len = len(new_programs)
 
@@ -669,6 +689,7 @@ def logProcessesMac():
                 if app in open_programs:
                     open_programs.remove(app)
                     print(f"{timestamp()} {USER} programClose {app.strip()}.app")
+                    screenshot = takeScreenshot()
                     session.post(consumerServer.SERVER_ADDR, json={
                         "timestamp": timestamp(),
                         "user": USER,
@@ -676,7 +697,8 @@ def logProcessesMac():
                         "application": app.strip(),
                         "event_type": "programClose",
                         "event_src_path": f"/Applications/{app.strip()}.app",
-                        "mouse_coord": mouse.position
+                        "mouse_coord": mouse.position,
+                        "screenshot": screenshot
                     })
 
         sleep(2)
@@ -700,11 +722,13 @@ def printerLogger():
         pj = print_job_watcher()
         print(
             f"{timestamp()} {pj.Owner} OperatingSystem printSubmitted {pj.Name}")
+        screenshot = takeScreenshot()
         session.post(consumerServer.SERVER_ADDR, json={
             "timestamp": timestamp(),
             "user": USER,
             "category": "OperatingSystem",
             "application": "Printer",
             "event_type": "printSubmitted",
-            "title": pj.Name
+            "title": pj.Name,
+            "screenshot": screenshot
         })

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,9 @@ applescript==2019.4.13; platform_system == "Darwin"
 MacFSEvents==0.8.1; platform_system == "Darwin"
 xlwings==0.18.0; platform_system == "Darwin"
 
+#16 Screenshot recorder dependencies / versions on 27/11/2023
+pillow==8.0.1
+
 # deprecated dependencies
 # matplotlib==3.3.2
 # opyenxes==0.3.0

--- a/utils/config.py
+++ b/utils/config.py
@@ -26,6 +26,10 @@ class MyConfig(PreferredConfig):
     # into one and a XES file is automatically generated, to be used for process mining techniques
     totalNumberOfRunGuiXes = IntOption('totalNumberOfRunGuiXes', default=1)
 
+    # Option in settings to control screenshot feature, if enabled, each event creats a screenshot of all screens visible
+    # and stores it in folder "screenshots"
+    capture_screenshots = BooleanOption('capture_screenshots', default=False)
+
     # Option in settings to control process discovery, if disabled, csv is generated but process discovery techniques
     # are not applied
     perform_process_discovery = BooleanOption('perform_process_discovery', default=True)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -120,6 +120,8 @@ def createLogFile():
     # logs = os.path.join(current_directory, 'logs')
     logs = os.path.join(MAIN_DIRECTORY, 'logs')
     createDirectory(logs)
+    screenshots = os.path.join(MAIN_DIRECTORY, 'screenshots')
+    createDirectory(screenshots)
     filename = timestamp("%Y-%m-%d_%H-%M-%S") + '.csv'
     log_filepath = os.path.join(logs, filename)
     # utils.config.MyConfig.get_instance().log_filepath = log_filepath

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -131,7 +131,6 @@ def createLogFile():
         f.writerow(modules.consumerServer.HEADER)
     return log_filepath
 
-
 def getRPADirectory(csv_file_path):
     """
     Genreate path to save RPA files.
@@ -436,6 +435,19 @@ def previous_and_next(some_iterable):
     nexts = chain(islice(nexts, 1, None), [None])
     return zip(prevs, items, nexts)
 
+def takeScreenshot(scrshtFormat: str ="png"):
+    """
+    Takes a screenshot of all attached and visible screens
+    Stores the screenshot in the location logs/screenshots
+
+    :param scrshtFormat: (Optional) File format of screenshot, Default type is png
+    :return: Name of the screenshot file
+    """
+    screenshot = ImageGrab.grab(all_screens=True)
+    imageName = "scrsht" + timestamp("%Y-%m-%d_%H-%M-%S") + "." + scrshtFormat
+    imagePath = "screenshots/" + imageName
+    screenshot.save(imagePath, format=scrshtFormat)
+    return imageName
 
 # ************
 # Class
@@ -530,19 +542,4 @@ else:
     FIREFOX = isInstalledLinux('firefox')
     EDGE = False
     OPERA = isInstalledLinux('opera')
-
-def takeScreenshot(scrshtFormat: str ="png"):
-    """
-    Takes a screenshot of all attached and visible screens
-    Stores the screenshot in the location logs/screenshots
-
-    :param scrshtFormat: (Optional) File format of screenshot, Default type is png
-    :return: Name of the screenshot file
-    """
-    screenshot = ImageGrab.grab(all_screens=True)
-    stamp = timestamp("%Y-%m-%d_%H-%M-%S")
-    folder = "screenshots/"
-    imageName = folder + "scrsht" + stamp + "." + scrshtFormat
-    screenshot.save(imageName, format=scrshtFormat)
-    
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -501,7 +501,7 @@ def takeScreenshot(save_image=True, scrshtFormat: str ="png"):
             
             # Guarda la imagen y elimina compresión
             Image.fromarray(img).save(filename, compress_level=0)
-    print(filename)
+    # print(filename)
     return filename
 
 # ************

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -228,7 +228,7 @@ def isPortInUse(port):
         return s.connect_ex(('127.0.0.1', port)) == 0
 
 
-def CSVEmpty(log_filepath, min_len=1):
+def CSVEmpty(log_filepath, min_len=0):
     """
     Check if given csv is empty by counting number of rows
 
@@ -240,6 +240,7 @@ def CSVEmpty(log_filepath, min_len=1):
         df = pandas.read_csv(log_filepath, encoding='utf-8-sig')
     except pandas.errors.EmptyDataError:
         return True
+    print(len(df))
     return df.empty or len(df) <= min_len
 
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -456,7 +456,7 @@ def get_last_directory_name(path):
     else:
         return None
 
-def takeScreenshot(save_image=True, scrshtFormat: str ="png"):
+def takeScreenshot(save_image: bool = utils.config.MyConfig.get_instance().capture_screenshots, scrshtFormat: str ="png"):
     """
     Takes a screenshot and saves it to a directory with a filename based on its hash, current date/time and order of capture.
 
@@ -466,32 +466,32 @@ def takeScreenshot(save_image=True, scrshtFormat: str ="png"):
     """
     # Future improvement: use onlx dxcam to capture multiple screens, because it is faster
     filename = ""
-    if dxcam.output_info().count("Output[") > 1:
-        # If there are more than two screens attached it is easier to use the pillow impage capture
-        screenshot = ImageGrab.grab(all_screens=True)
-        imageName = "scrsht" + timestamp("%Y-%m-%d_%H-%M-%S") + "." + scrshtFormat
-        filename = "screenshots/" + imageName
-        screenshot.save(filename, format=scrshtFormat)
+    if save_image:
+        if dxcam.output_info().count("Output[") > 1:
+            # If there are more than two screens attached it is easier to use the pillow impage capture
+            screenshot = ImageGrab.grab(all_screens=True)
+            imageName = "scrsht" + timestamp("%Y-%m-%d_%H-%M-%S") + "." + scrshtFormat
+            filename = "screenshots/" + imageName
+            screenshot.save(filename, format=scrshtFormat)
 
-    else:
-        global camera  # usa la variable global camera
+        else:
+            global camera  # usa la variable global camera
 
-        # Si no hay instancia de cámara, crear una nueva instancia
-        if camera is None:
-            camera = dxcam.create()
-            print("Creating new camera instance")
-        img = camera.grab()
+            # Si no hay instancia de cámara, crear una nueva instancia
+            if camera is None:
+                camera = dxcam.create()
+                print("Creating new camera instance")
+            img = camera.grab()
 
-        # Calculamos el hash de la imagen
-        sha256_hash = hashlib.sha256()
-        sha256_hash.update(img)
-        hashed_img = sha256_hash.hexdigest()
+            # Calculamos el hash de la imagen
+            sha256_hash = hashlib.sha256()
+            sha256_hash.update(img)
+            hashed_img = sha256_hash.hexdigest()
 
-        # Acortar el hash para el nombre
-        short_hash = hashed_img[:8]
+            # Acortar el hash para el nombre
+            short_hash = hashed_img[:8]
 
-        # Guardar la imagen en el directorio correspondiente. Nombre dependiente de hash
-        if save_image:
+            # Guardar la imagen en el directorio correspondiente. Nombre dependiente de hash
             directory = "screenshots/"
             if not os.path.exists(directory):
                 createDirectory(directory)
@@ -501,7 +501,7 @@ def takeScreenshot(save_image=True, scrshtFormat: str ="png"):
             
             # Guarda la imagen y elimina compresión
             Image.fromarray(img).save(filename, compress_level=0)
-    # print(filename)
+
     return filename
 
 # ************

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -24,6 +24,9 @@ from itertools import tee, islice, chain
 # asynchronous session.post requests to log server, used by multiple modules
 from requests_futures.sessions import FuturesSession
 
+# screenshot recording feature
+from PIL import ImageGrab
+
 session = FuturesSession()
 
 # ************
@@ -73,15 +76,18 @@ UIPATH_FOLDER = "UiPath"
 # ************
 
 
-def timestamp():
+def timestamp(format=None):
     """
     Generate current timestamp in ISO format (e.g. '2020-08-29T16:42:30.690')
 
-    :return: timestamp in ISO format
-    """
+    :param format: format (Default None) specifies the datetime format, if none it is ISO Format
 
-    #return datetime.now().strftime("%Y-%m-%d %H:%M:%S:%f")  # [:-3]
-    return datetime.now().isoformat(timespec='milliseconds')
+    :return: timestamp in (ISO) format
+    """
+    if format == None:
+        return datetime.now().isoformat(timespec='milliseconds')
+    else:
+        return datetime.now().strftime(format)
 
 
 def createDirectory(path):
@@ -522,3 +528,18 @@ else:
     FIREFOX = isInstalledLinux('firefox')
     EDGE = False
     OPERA = isInstalledLinux('opera')
+
+def takeScreenshot():
+    """
+    Takes a screenshot of all attached and visible screens
+    Stores the screenshot in the location logs/screenshots
+    """
+    screenshot = ImageGrab.grab(all_screens=True)
+
+    timestamp=timestamp()
+    print(timestamp)
+    folder = "../log/images"
+    imageName = folder + "scrsht_" + str(timestamp) + ".png"
+    screenshot.save(imageName, format='PNG')
+    
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -120,7 +120,7 @@ def createLogFile():
     # logs = os.path.join(current_directory, 'logs')
     logs = os.path.join(MAIN_DIRECTORY, 'logs')
     createDirectory(logs)
-    filename = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + '.csv'
+    filename = timestamp("%Y-%m-%d_%H-%M-%S") + '.csv'
     log_filepath = os.path.join(logs, filename)
     # utils.config.MyConfig.get_instance().log_filepath = log_filepath
     # create HEADER
@@ -136,7 +136,7 @@ def getRPADirectory(csv_file_path):
 
     RPA_directory is like /Users/marco/Desktop/ComputerLogger/RPA/2020-02-25_23-21-57
 
-    :param csv_file_path: path of event log in input
+    :param csv_file_path str: path of event log in input
     :return: path of RPA directory
     """
     csv_filename = getFilename(csv_file_path)
@@ -529,17 +529,18 @@ else:
     EDGE = False
     OPERA = isInstalledLinux('opera')
 
-def takeScreenshot():
+def takeScreenshot(scrshtFormat: str ="png"):
     """
     Takes a screenshot of all attached and visible screens
     Stores the screenshot in the location logs/screenshots
+
+    :param scrshtFormat: (Optional) File format of screenshot, Default type is png
+    :return: Name of the screenshot file
     """
     screenshot = ImageGrab.grab(all_screens=True)
-
-    timestamp=timestamp()
-    print(timestamp)
-    folder = "../log/images"
-    imageName = folder + "scrsht_" + str(timestamp) + ".png"
-    screenshot.save(imageName, format='PNG')
+    stamp = timestamp("%Y-%m-%d_%H-%M-%S")
+    folder = "screenshots/"
+    imageName = folder + "scrsht" + stamp + "." + scrshtFormat
+    screenshot.save(imageName, format=scrshtFormat)
     
 


### PR DESCRIPTION
A screenshot recording option was added to capture screenshots during the execution.
All events in System logger and office logger where updated with takeScreenshot method.

However, the javascript of the browser logger does not allow to capture full screen. Thus, another idea has to be implemented in the future.