### PR TITLE
Replaced DXCam with PyAutoGUI for capturing screenshots

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -41,6 +41,7 @@ xlwings==0.18.0; platform_system == "Darwin"
 #16 Screenshot recorder dependencies / versions on 27/11/2023
 pillow==10.2.0
 dxcam; platform_system == "Windows"
+pyautogui==0.9.54
 screeninfo
 
 #Process Mining specific dependencies


### PR DESCRIPTION
### Summary
- A bug was found where the execution breaks if DXCam captures two identical screenshots consecutively when no changes occur between actions.
- DXCam is replaced with PyAutoGUI to avoid this issue.

### Changes
- Replaced DXCam with PyAutoGUI for more stable screen captures.
- Added timestamp before hash in screenshot filenames to ensure proper ordering.
- Updated `requirements.txt` to include PyAutoGUI.

### Details
- PIL was tested for replacing DXCam, but it caused duplicate images in the action log with the same hash.
- PyAutoGUI showed no errors and offers similar performance to PIL, but does not support multi-monitor capture.
- PIL is kept for multi-monitor support, while DXCam is replaced by PyAutoGUI for single-monitor captures.

### Future Work
- It is proposed to explore and evaluate alternative libraries that are faster and more efficient than PyAutoGUI for capturing screenshots, particularly with support for multi-monitor setups. This could provide performance improvements and better optimization in future iterations.

### Note
- DXCam has not been supported since last year, after initially emerging as a new tool.
